### PR TITLE
Create ConfirmationModal component

### DIFF
--- a/src/components/common/ConfirmationModal.vue
+++ b/src/components/common/ConfirmationModal.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="tint">
+    <div class="window white">
+      <div class="content">
+        <div class="inner-content">
+          <p class="text">
+            {{message}}
+          </p>
+
+          <button
+            class="s-button s-button--primary s-button--submit"
+            @click="confirmAction"
+          >
+            {{buttonText}}
+          </button>
+        </div>
+
+        <button
+          class="s-button s-button--additional s-button--close"
+          @click="$emit('close')"
+        >
+          <img :src="publicPath + 'close.svg'" alt="Close" />
+        </button>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: "ConfirmationModal",
+  props: ["message", "buttonText"],
+  computed: {
+    publicPath() {
+      return process.env.BASE_URL;
+    },
+  },
+  methods: {
+    async confirmAction() {
+      this.$emit("onConfirmAction");
+    },
+  },
+};
+</script>
+
+<style scoped>
+* {
+  box-sizing: border-box;
+}
+.tint {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.42);
+}
+.window.white {
+  max-width: 490px;
+  height: auto;
+  max-height: 85%;
+  padding: 0;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.09);
+}
+.content {
+  position: relative;
+  height: calc(100% - 88px);
+  overflow: hidden;
+}
+.inner-content {
+  padding: 50px 26px 26px;
+  text-align: center;
+}
+.text {
+  margin: 20px 0 40px 0;
+  font-family: BrandonGrotesque, sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 21px;
+  letter-spacing: -0.2px;
+  color: #414a5b;
+}
+.s-button.s-button--close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border-radius: 50%;
+  z-index: 1;
+}
+.s-button.s-button--submit {
+  margin: 0 auto;
+}
+</style>

--- a/src/components/deposit/Deposit.vue
+++ b/src/components/deposit/Deposit.vue
@@ -280,7 +280,10 @@
           "
           @click="
             justDeposit = true;
-            handle_add_liquidity();
+            if (depositc)
+              handle_add_liquidity();
+            else
+              toggleConfirmationModal();
           "
         >
           Deposit
@@ -392,6 +395,12 @@
         </p>
       </div>
     </div>
+    <ConfirmationModal
+      message="Depositing unwrapped is known to be problematic and has a high probability of failing."
+      buttonText="Continue with Deposit"
+      @onConfirmAction="confirmUnwrappedDeposit"
+      v-if="showConfirmationModal"
+      @close="toggleConfirmationModal" />
   </div>
 </template>
 
@@ -417,15 +426,18 @@ import BN from "bignumber.js";
 
 import Slippage from "../common/Slippage.vue";
 
+import ConfirmationModal from "@/components/common/ConfirmationModal";
+
 export default {
   components: {
     Slippage,
     GasPrice,
+    ConfirmationModal,
   },
   data: () => ({
     disabled: false,
     disabledButtons: true,
-    disabledForLaunch: true,
+    disabledForLaunch: false,
     sync_balances: false,
     max_balances: true,
     inf_approval: true,
@@ -460,8 +472,8 @@ export default {
     loadingAction: false,
     errorStaking: false,
     slippagePromise: helpers.makeCancelable(Promise.resolve()),
-
     hasRewards: true,
+    showConfirmationModal: false,
   }),
   async created() {
     this.$watch(
@@ -911,6 +923,13 @@ export default {
           .find((deposit_zap) => deposit_zap == event.address.toLowerCase()) !==
           undefined
       );
+    },
+    toggleConfirmationModal: function () {
+      this.showConfirmationModal = !this.showConfirmationModal;
+    },
+    confirmUnwrappedDeposit: function() {
+      this.handle_add_liquidity();
+      this.toggleConfirmationModal();
     },
     async handle_add_liquidity(stake = false) {
       let actionType = stake == false ? 1 : 2;


### PR DESCRIPTION
Created a ConfirmationModal inspired by the ClaimSnowPopup. Show the modal as a warning prior to depositing unwrapped stablecoins. Re-enable the deposit of unwrapped stablecoins.

<img width="674" alt="screenshot-confirmation-modal" src="https://user-images.githubusercontent.com/7877264/104037046-0b7c5880-5189-11eb-8411-4dc56672c298.png">